### PR TITLE
feat(markdown): add mermaid diagrams support

### DIFF
--- a/themes/api-platform/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/themes/api-platform/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,9 @@
+<div class="mermaid-container relative flex justify-center items-center">
+  <div class="mermaid-loader absolute inset-0 flex items-center justify-center">
+    <div class="w-6 h-6 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+  </div>
+  <pre class="mermaid opacity-0">
+      {{- .Inner | safeHTML }}
+    </pre>
+</div>
+{{ .Page.Store.Set "hasMermaid" true }}

--- a/themes/api-platform/layouts/_default/baseof.html
+++ b/themes/api-platform/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="{{ or site.Language.LanguageCode site.Language.Lang }}" dir="{{ or site.Language.LanguageDirection `ltr` }}" class="w-full light">
 <head>
   {{ partial "head.html" . }}
+  {{ partial "mermaid.html" . }}
 </head>
 <body class="bg-white dark:bg-blue-black">
 	<div class="relative w-full overflow-x-clip bg-white dark:bg-blue-black">

--- a/themes/api-platform/layouts/partials/mermaid.html
+++ b/themes/api-platform/layouts/partials/mermaid.html
@@ -1,0 +1,17 @@
+{{ if .Store.Get "hasMermaid" }}
+    <script type="module">
+        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
+
+        mermaid.initialize({ startOnLoad: true });
+
+        document.addEventListener("DOMContentLoaded", () => {
+            mermaid.init(undefined, document.querySelectorAll(".mermaid")).then(() => {
+                document.querySelectorAll(".mermaid").forEach((el) => {
+                    el.style.opacity = 1;
+                    const loader = el.closest(".mermaid-container").querySelector(".mermaid-loader");
+                    if (loader) loader.style.display = "none";
+                });
+            });
+        });
+    </script>
+{{ end }}


### PR DESCRIPTION
As discussed internally, the mermaid graphics don't work on the website whereas they work perfectly in MD files using the GitHub preview.

This is caused by `hugo` not natively supporting mermaid in MD files.
Here's a support proposal inspired by hugo's documentation [mermaid diagrams](https://gohugo.io/content-management/diagrams/#mermaid-diagrams). By the way, I've added a loader that displays while the mermaid graphic is rendered.

Website (before)

![image](https://github.com/user-attachments/assets/dacc8e57-fd44-4823-9a2c-d5389cd99c03)

MD file with GitHub preview

![image](https://github.com/user-attachments/assets/1653d017-238c-4175-8ace-3f4c47fc9ec3)

Website (after this feature support)

![image](https://github.com/user-attachments/assets/5ce43884-8fbf-4fa0-974d-567b3f8376f2)
