### PR TITLE
Fix remove diff signs when copying code from code blocks

### DIFF
--- a/themes/api-platform/hugo.toml
+++ b/themes/api-platform/hugo.toml
@@ -4,4 +4,5 @@ languageCode = 'en-us'
 [module]
   [module.hugoVersion]
     extended = false
-    min = "0.116.0"
+    min = "0.134.2"
+

--- a/themes/api-platform/layouts/_default/_markup/render-codeblock.html
+++ b/themes/api-platform/layouts/_default/_markup/render-codeblock.html
@@ -1,0 +1,15 @@
+{{ partial "render-codeblock.html" . }}
+
+<script type="module">
+    document.addEventListener("DOMContentLoaded", function () {
+        document.addEventListener('copy', function (e) {
+            e.preventDefault();
+
+            const selection = window.getSelection();
+            const selectedText = selection.toString();
+            const cleanedText = selectedText.replace(/^[+-]\s*/gm, '');
+
+            e.clipboardData.setData('text/plain', cleanedText);
+        });
+    });
+</script>

--- a/themes/api-platform/layouts/partials/render-codeblock.html
+++ b/themes/api-platform/layouts/partials/render-codeblock.html
@@ -1,0 +1,2 @@
+{{ $result := transform.HighlightCodeBlock . }}
+{{ replaceRE `\x60&lt;a href=&#34;(.+)?&#34;&gt;(.+)?&lt;\/a&gt;\x60` "<a href=\"$1\">$2</a>" $result.Wrapped | safeHTML }}

--- a/themes/api-platform/layouts/reference/_markup/render-codeblock.html
+++ b/themes/api-platform/layouts/reference/_markup/render-codeblock.html
@@ -1,2 +1,1 @@
-{{ $result := transform.HighlightCodeBlock . }}
-{{ replaceRE `\x60&lt;a href=&#34;(.+)?&#34;&gt;(.+)?&lt;\/a&gt;\x60` "<a href=\"$1\">$2</a>" $result.Wrapped | safeHTML }}
+{{ partial "render-codeblock.html" . }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `main`
| Tickets       | Closes #10 
| License       | MIT

After several solution tests (rendering the doc block code in HTML table tags, modifying Hugo's configuration and the modules concerned, etc.), the functional solution chosen is to use Javascript on the `copy` event to remove the diff operators. 

Also includes:
- Minimal version of `Hugo` synchronized with [api-platform/docs CD](https://github.com/api-platform/docs/blob/129ea776df4af0b967ffc18e4e1aa2921cae90ec/.github/workflows/cd.yml#L42)

