### PR TITLE
fix: llms templates break Hugo 0.134.2 build (strings.TrimSpace)

### DIFF
--- a/themes/api-platform/layouts/index.llms.txt
+++ b/themes/api-platform/layouts/index.llms.txt
@@ -10,7 +10,8 @@
 {{ range $ch.items -}}
 {{- $path := cond (eq . "index") (printf "/%s" $ch.path) (printf "/%s/%s" $ch.path .) -}}
 {{- with $.Site.GetPage $path -}}
-- [{{ partial "extract-h1.html" . | plainify | strings.TrimSpace }}]({{ .Permalink }})
+{{- $title := trim (partial "extract-h1.html" . | plainify) " \r\n\t" -}}
+- [{{ $title }}]({{ .Permalink }})
 {{ end -}}
 {{- end -}}
 {{- end }}

--- a/themes/api-platform/layouts/index.llmsfull.txt
+++ b/themes/api-platform/layouts/index.llmsfull.txt
@@ -11,7 +11,7 @@ Source: {{ $base }}/
 
 ---
 
-# {{ partial "extract-h1.html" . | plainify | strings.TrimSpace }}
+# {{ trim (partial "extract-h1.html" . | plainify) " \r\n\t" }}
 
 Source: {{ .Permalink }}
 


### PR DESCRIPTION
## Problem
After #30 merged, the docs deploy's **Hugo** step failed:

```
index.llms.txt:13: execute of template failed: at <strings>: can't evaluate field TrimSpace in type interface
```

`strings.TrimSpace` is not exposed in the Hugo version pinned by `api-platform/docs` `cd.yml` (**0.134.2**), so the build aborted before `Generate llms.txt` / `Deploy` ran. No upload happened, so the live site was unaffected — but **no deploy can succeed** until this is fixed.

(It worked locally because newer Hugo does expose `strings.TrimSpace`.)

## Fix
Use the long-standing global `trim` with an explicit cutset instead. Verified by building with **hugo 0.134.2 extended** (the CI version): exit 0, `llms.txt` (8.4K), `llms-full.txt` (1 MB), `sitemap.xml` intact, titles correct.

Follow-up to #30.